### PR TITLE
Support Additional Error Output Formats

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -19,5 +19,5 @@ class Puppet(Linter):
 
     syntax = 'puppet'
     cmd = ('puppet', 'parser', 'validate', '--color=false')
-    regex = r'^Error:.+?(?P<message>Syntax error at \'(?P<near>.+?)\'; expected \'.+\').+?line (?P<line>\d+)'
+    regex = r'^Error:.+?(?P<message>Syntax error at \'?(?P<near>.+?)\'?(?:; expected \'.+\')?) at line (?P<line>\d+)'
     error_stream = util.STREAM_STDERR


### PR DESCRIPTION
Make the 'near' match group more flexible to support multiple error
output styles for some syntax errors.

Examples:

    Error: Could not parse for environment production: Syntax error at 'class' at line 27
    Error: Could not parse for environment production: Syntax error at end of file at line 32
    Error: Could not parse for environment production: Syntax error at ','; expected '}' at line 28

See https://regex101.com/r/aT3aR3/3 for testing